### PR TITLE
Fix Hudi Metadata segfault during named collection reload

### DIFF
--- a/src/Common/NamedCollections/NamedCollectionsFactory.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.cpp
@@ -228,6 +228,9 @@ namespace
 
 void NamedCollectionFactory::loadIfNot()
 {
+    if (loaded)
+        return;
+
     std::lock_guard lock(mutex);
     loadIfNot(lock);
 }
@@ -266,6 +269,7 @@ void NamedCollectionFactory::reloadFromConfig(const Poco::Util::AbstractConfigur
     auto context = Context::getGlobalContextInstance();
     std::set<String> new_or_changed;
     std::set<String> removed;
+    std::lock_guard reload_lock(reload_mutex);
     {
         std::lock_guard lock(mutex);
         if (loadIfNot(lock))

--- a/src/Common/NamedCollections/NamedCollectionsFactory.h
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.h
@@ -43,6 +43,7 @@ public:
 protected:
     mutable NamedCollectionsMap loaded_named_collections;
     mutable std::mutex mutex;
+    mutable std::mutex reload_mutex;
 
     const LoggerPtr log = getLogger("NamedCollectionFactory");
 

--- a/src/Storages/ObjectStorage/DataLakes/IStorageDataLake.h
+++ b/src/Storages/ObjectStorage/DataLakes/IStorageDataLake.h
@@ -112,9 +112,11 @@ public:
         auto new_metadata = DataLakeMetadata::create(object_storage, base_configuration, local_context);
         if (current_metadata && *current_metadata == *new_metadata)
             return;
+        configuration->setPaths(new_metadata->getDataFiles());
+        const auto & columns = new_metadata->getPartitionColumns();
         current_metadata = std::move(new_metadata);
-        configuration->setPaths(current_metadata->getDataFiles());
-        configuration->setPartitionColumns(current_metadata->getPartitionColumns());
+        base_configuration->setPartitionColumns(columns);
+        configuration->setPartitionColumns(columns);
     }
 
     // Called when the named collection exists and has correct information
@@ -127,10 +129,10 @@ public:
             /*with_table_structure*/false,
             /*allow_missing_named_collection*/false
         );
-        namedCollectionRestored();
         base_configuration = std::move(reloaded_configuration);
+        configuration = base_configuration->clone();
         object_storage = base_configuration->createObjectStorage(context_, /* is_readonly */true);
-        updateConfiguration(context_);
+        namedCollectionRestored();
 }
 
 


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):

- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix crash during Hudi Metadata reload