### PR TITLE
Fix regression in DataLake named collection reloading

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/IStorageDataLake.h
+++ b/src/Storages/ObjectStorage/DataLakes/IStorageDataLake.h
@@ -130,7 +130,7 @@ public:
             /*allow_missing_named_collection*/false
         );
         base_configuration = std::move(reloaded_configuration);
-        configuration = base_configuration->clone();
+        base_configuration->check(context_);
         object_storage = base_configuration->createObjectStorage(context_, /* is_readonly */true);
         namedCollectionRestored();
 }


### PR DESCRIPTION
When setting the configuration attribute to a copy of the base
configuration by cloning it, Iceberg and DataLake implementations are
unable to correctly reach the remote object storage through the
``StorageObjectStorageSource`` anymore.
