### PR TITLE
Change: Replicated engine in create database by default [DDB-1615]

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1980,9 +1980,13 @@ BlockIO InterpreterCreateQuery::createReplicatedDatabaseByClient() {
     DatabaseReplicated * replicated_database = dynamic_cast<DatabaseReplicated *>(default_database.get());
     if (!replicated_database)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Database default should have Replicated engine");
+    String if_not_exists_fragment = "";
+    if (create.if_not_exists)
+        if_not_exists_fragment = " IF NOT EXISTS ";
     checkMaxDatabaseNumToThrow();
     String db_name = create.getDatabase();
-    String create_db_query = "CREATE DATABASE " + escapeString(db_name) + " ON CLUSTER " + escapeString(cluster_database) +
+    String create_db_query = "CREATE DATABASE " + if_not_exists_fragment + escapeString(db_name) +
+        " ON CLUSTER " + escapeString(cluster_database) +
         " ENGINE = Replicated("
         "'/clickhouse/databases/" + escapeForFileName(db_name) +
         "', '" + replicated_database->getShardMacros() + "', '{replica}') "
@@ -2002,7 +2006,7 @@ void InterpreterCreateQuery::checkDatabaseNameAllowed() {
     if (internal)
         return;
     auto *storage = create.storage;
-    if (!storage || !storage->engine || storage->engine->name != "Replicated")
+    if (storage && storage->engine && storage->engine->name != "Replicated")
         return;
     String db_name = create.getDatabase();
     auto context = getContext();
@@ -2039,12 +2043,14 @@ BlockIO InterpreterCreateQuery::execute()
     auto user_with_interect_db_creation = context->getServerSettings().getString("user_with_indirect_database_creation");
     if (is_create_database && !user_with_interect_db_creation.empty() && username == user_with_interect_db_creation && !internal) {
         auto *storage = create.storage;
-        if (!storage || !storage->engine || storage->engine->name != "Replicated")
-            throw Exception(ErrorCodes::ACCESS_DENIED, "Only Replicated database can be created through SQL.");
-        if (storage->engine->arguments && storage->engine->arguments->children.size() > 0)
-            throw Exception(ErrorCodes::UNSUPPORTED_PARAMETER, "Arguments cannot be specified for Replicated database engine.");
-        if (storage && storage->settings && storage->settings->changes.size() > 0) {
-            throw Exception(ErrorCodes::UNSUPPORTED_PARAMETER, "Settings are not allowed for Replicated database.");
+        if (storage) {
+            if (storage->engine && storage->engine->name != "Replicated")
+                throw Exception(ErrorCodes::ACCESS_DENIED, "Only Replicated database can be created through SQL.");
+            if (storage->engine && storage->engine->arguments && storage->engine->arguments->children.size() > 0)
+                throw Exception(ErrorCodes::UNSUPPORTED_PARAMETER, "Arguments cannot be specified for Replicated database engine.");
+            if (storage->settings && storage->settings->changes.size() > 0) {
+                throw Exception(ErrorCodes::UNSUPPORTED_PARAMETER, "Settings are not allowed for Replicated database.");
+            }
         }
         if (!create.cluster.empty())
             throw Exception(ErrorCodes::UNSUPPORTED_PARAMETER, "ON CLUSTER cannot be used in CREATE DATABASE, it will be set implicitly.");


### PR DESCRIPTION
In 3a64b2b we allowed a low privilege user to create a database.
This commit makes possible to connect external tools like Airbyte using restricted users.
Changes:
1. Use `Replicated` database engine by default
2. Pass `if exists` to the main `create database` statement

[DDB-1615]

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


[DDB-1615]: https://aiven.atlassian.net/browse/DDB-1615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ