### PR TITLE
Fix: enforce `on cluster` for users with limited access

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -8,6 +8,7 @@
 #include <Interpreters/QueryLog.h>
 #include <IO/SharedThreadPools.h>
 #include <Access/Common/AccessRightsElement.h>
+#include <Access/ContextAccess.h>
 #include <Parsers/ASTDropQuery.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Storages/IStorage.h>
@@ -16,6 +17,7 @@
 #include <Common/quoteString.h>
 #include <Common/typeid_cast.h>
 #include <Core/Settings.h>
+#include <Core/ServerSettings.h>
 #include <Databases/DatabaseReplicated.h>
 
 #include "config.h"
@@ -34,6 +36,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ACCESS_DENIED;
+    extern const int SETTING_CONSTRAINT_VIOLATION;
     extern const int LOGICAL_ERROR;
     extern const int SYNTAX_ERROR;
     extern const int UNKNOWN_TABLE;
@@ -84,13 +87,30 @@ BlockIO InterpreterDropQuery::executeSingleDropQuery(const ASTPtr & drop_query_p
     if (getContext()->getSettingsRef().database_atomic_wait_for_drop_and_detach_synchronously)
         drop.sync = true;
 
+    // Enforce `ON CLUSTER {default}` for ordinary users to ensure complete database removal.
+    auto query_context = getContext();
+    auto access = query_context->getAccess();
+    auto is_drop_database = drop.database && !drop.table;
+    if (is_drop_database
+        && !maybeRemoveOnCluster(current_query_ptr, getContext())
+        && !access->isGranted(AccessType::PROTECTED_ACCESS_MANAGEMENT)) {
+        if (drop.kind == ASTDropQuery::Kind::Detach)
+            throw Exception(ErrorCodes::ACCESS_DENIED, "Database detach is not allowed.");
+        auto cluster_database = query_context->getServerSettings().getString("cluster_database");
+        if (cluster_database.empty())
+            throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "Setting cluster_database should be set.");
+        if (!drop.cluster.empty() && drop.cluster != cluster_database)
+            throw Exception(ErrorCodes::ACCESS_DENIED, "Cannot execute query on specified cluster.");
+        drop.cluster = cluster_database;
+    }
+
     if (drop.table)
         return executeToTable(drop);
     else if (drop.database && !drop.cluster.empty() && !maybeRemoveOnCluster(current_query_ptr, getContext()))
     {
         DDLQueryOnClusterParams params;
         params.access_to_check = getRequiredAccessForDDLOnCluster();
-        return executeDDLQueryOnCluster(current_query_ptr, getContext(), params);
+        return executeDDLQueryOnCluster(current_query_ptr, query_context, params, true);
     }
     else if (drop.database)
         return executeToDatabase(drop);

--- a/src/Interpreters/executeDDLQueryOnCluster.cpp
+++ b/src/Interpreters/executeDDLQueryOnCluster.cpp
@@ -64,7 +64,7 @@ bool isSupportedAlterTypeForOnClusterDDLQuery(int type)
 }
 
 
-BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, const DDLQueryOnClusterParams & params)
+BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, const DDLQueryOnClusterParams & params, bool skip_distributed_checks)
 {
     OpenTelemetry::SpanHolder span(__FUNCTION__, OpenTelemetry::SpanKind::PRODUCER);
 
@@ -82,7 +82,7 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, 
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Distributed execution is not supported for such DDL queries");
     }
 
-    if (!context->getSettingsRef().allow_distributed_ddl)
+    if (!skip_distributed_checks && !context->getSettingsRef().allow_distributed_ddl)
         throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Distributed DDL queries are prohibited for the user");
 
     if (const auto * query_alter = query_ptr->as<ASTAlterQuery>())
@@ -107,7 +107,8 @@ BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr_, ContextPtr context, 
         throw Exception(ErrorCodes::QUERY_IS_PROHIBITED, "Distributed DDL queries are prohibited for the cluster");
 
     /// TODO: support per-cluster grant
-    context->checkAccess(AccessType::CLUSTER);
+    if (!skip_distributed_checks)
+        context->checkAccess(AccessType::CLUSTER);
 
     /// NOTE: if `async_load_databases = true`, then it block until ddl_worker is started, which includes startup of all related tables.
     DDLWorker & ddl_worker = context->getDDLWorker();

--- a/src/Interpreters/executeDDLQueryOnCluster.h
+++ b/src/Interpreters/executeDDLQueryOnCluster.h
@@ -41,7 +41,7 @@ struct DDLQueryOnClusterParams
 
 /// Pushes distributed DDL query to the queue.
 /// Returns DDLQueryStatusSource, which reads results of query execution on each host in the cluster.
-BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr, ContextPtr context, const DDLQueryOnClusterParams & params = {});
+BlockIO executeDDLQueryOnCluster(const ASTPtr & query_ptr, ContextPtr context, const DDLQueryOnClusterParams & params = {}, bool skip_distributed_checks = false);
 
 BlockIO getDistributedDDLStatus(const String & node_path, const DDLLogEntry & entry, ContextPtr context, const Strings * hosts_to_wait);
 


### PR DESCRIPTION
In 3a64b2b we allowed a low privilege user to create a database.
Those users could delete database. The `on cluster` clause is necessary for a consistent database deletion (from all replicas), while it was not enforced before.

[DDB-1839]

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


[DDB-1839]: https://aiven.atlassian.net/browse/DDB-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ