### PR TITLE
Fixes to `0064-Lazy_certificates.patch`

### DIFF
--- a/src/Server/CertificateReloader.cpp
+++ b/src/Server/CertificateReloader.cpp
@@ -115,8 +115,11 @@ std::list<CertificateReloader::MultiData>::iterator CertificateReloader::findOrI
 void CertificateReloader::tryLoadImpl(const Poco::Util::AbstractConfiguration & config, SSL_CTX * ctx, const std::string & prefix)
 {
     /// If we don't need certificates, do nothing
-    if (config.getString("tcp_secure_port", "").empty() && config.getString("https_port", "").empty())
+    if (!config.has("tcp_port_secure") && !config.has("https_port"))
+    {
+        LOG_INFO(log, "No certificates needed as tcp_port_secure and https_port are not set");
         return;
+    }
 
     /// If at least one of the files is modified - recreate
 


### PR DESCRIPTION
This commit is a fixup commit for an older patch for CertificateReloader. It addresses two issues:

1. Typo fix. `tcp_secure_port` should be `tcp_port_secure`
2. Previous approach read the config value (that may be provided by ZooKeeper) and checked if the value was not empty. This caused an issue when ClickHouse started while ZooKeeper wasn't fully ready. Because of that, ZooKeeper returned empty strings for `tcp_port_secure` and `https_port` causing ClickHouse to think that no certificates are needed to be read. Since this code is being executed only during the server initialization, it caused ClickHouse to ignore the future changes in the certificates

Additionally, this commit adds a log line in case no certificates are being read to be clear when such a scenario occurs.

[DDB-1898]



[DDB-1898]: https://aiven.atlassian.net/browse/DDB-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ