### PR TITLE
Properly fix 0064-Lazy_certificates.patch

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1752,7 +1752,7 @@ try
 
             CompressionCodecEncrypted::Configuration::instance().tryLoad(*config, "encryption_codecs");
 #if USE_SSL
-            CertificateReloader::instance().tryReloadAll(*config);
+            CertificateReloader::instance().tryLoad(*config);
 #endif
             NamedCollectionFactory::instance().reloadFromConfig(*config);
 

--- a/src/Server/CertificateReloader.cpp
+++ b/src/Server/CertificateReloader.cpp
@@ -115,9 +115,9 @@ std::list<CertificateReloader::MultiData>::iterator CertificateReloader::findOrI
 void CertificateReloader::tryLoadImpl(const Poco::Util::AbstractConfiguration & config, SSL_CTX * ctx, const std::string & prefix)
 {
     /// If we don't need certificates, do nothing
-    if (!config.has("tcp_port_secure") && !config.has("https_port"))
+    if (config.getString("tcp_port_secure", "").empty() && config.getString("https_port", "").empty())
     {
-        LOG_INFO(log, "No certificates needed as tcp_port_secure and https_port are not set");
+        LOG_INFO(log, "No certificates needed as tcp_port_secure and https_port are not provided");
         return;
     }
 


### PR DESCRIPTION
Previous fix was incorrect as statement
`!config.has("tcp_port_secure") && !config.has("https_port")` was always true, even when certificates were not ready yet. This reintroduced the problem when ClickHouse tried to load certificates and errored out with "No such file or directory", which the original patch tried to fix.

The proper approach to the problem is to make sure there's one successful call for `tryLoad` before calling `tryReloadAll`. During the research it was noticed that `tryLoad` loads exactly one prefix `"openSSL.server."` and there's no place in the code that adds another prefix (at least in our usecase). This means that `tryReloadAll` acts effectively the same as `tryLoad`.

This commit restores the original if-statement thus fixing the error while loading the non-existent certificates. Additionally, it replaces the call for `tryReloadAll` from `main_config_reloader` with the call for `tryLoad` for the reasons explained above.

This commit has been tested in the test environment and proved to be working.

[DDB-1898]




[DDB-1898]: https://aiven.atlassian.net/browse/DDB-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ