### PR TITLE
Add replicated_database_logs_to_keep server setting

### DIFF
--- a/src/Core/ServerSettings.h
+++ b/src/Core/ServerSettings.h
@@ -173,7 +173,8 @@ namespace DB
     M(Bool, disable_insertion_and_mutation, false, "Disable all insert/alter/delete queries. This setting will be enabled if someone needs read-only nodes to prevent insertion and mutation affect reading performance.", 0) \
     M(String, reserved_replicated_database_prefixes, "", "Comma separated list of prohibited replicated database prefixes.", 0) \
     M(String, user_with_indirect_database_creation, "", "Database creation for this user is simplified by setting necessary parameters automatically and prohibiting dangerous behavoir.", 0) \
-    M(String, cluster_database, "", "Database used for cluster creation.", 0)
+    M(String, cluster_database, "", "Database used for cluster creation.", 0) \
+    M(UInt32, replicated_database_logs_to_keep, 300, "Number of logs to keep in ZooKeeper for replicated databases.", 0) \
 
 /// If you add a setting which can be updated at runtime, please update 'changeable_settings' map in StorageSystemServerSettings.cpp
 

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -554,7 +554,8 @@ bool DatabaseReplicated::createDatabaseNodesInZooKeeper(const zkutil::ZooKeeperP
     ops.emplace_back(zkutil::makeRemoveRequest(zookeeper_path + "/counter/cnt-", -1));
     ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/metadata", "", zkutil::CreateMode::Persistent));
     ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/max_log_ptr", "1", zkutil::CreateMode::Persistent));
-    ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/logs_to_keep", "1000", zkutil::CreateMode::Persistent));
+    auto logs_to_keep = getContext()->getServerSettings().replicated_database_logs_to_keep;
+    ops.emplace_back(zkutil::makeCreateRequest(zookeeper_path + "/logs_to_keep", std::to_string(logs_to_keep), zkutil::CreateMode::Persistent));
 
     Coordination::Responses responses;
     auto res = current_zookeeper->tryMulti(ops, responses);


### PR DESCRIPTION
Add replicated_database_logs_to_keep server setting
    
This setting allows changing default number of replicated
database logs stored in zookeeper.
Default value is changed from 1000 to 300 to greatly reduce
zookeeper resource consumption for setups with many databases.