### PR TITLE
Fix default profile escape

### DIFF
--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -667,6 +667,24 @@ void AccessControl::setDefaultProfileName(const String & default_profile_name)
 }
 
 
+std::optional<UUID> AccessControl::getDefaultProfileId() const
+{
+    return settings_profiles_cache->getDefaultProfileId();
+}
+
+
+bool AccessControl::isDefaultProfileOrDescendant(const UUID & profile_id) const
+{
+    return settings_profiles_cache->isDefaultProfileOrDescendant(profile_id);
+}
+
+
+bool AccessControl::isExpectedProfileOrDescendant(const UUID & profile_id, const UUID & expected_id) const
+{
+    return settings_profiles_cache->isExpectedProfileOrDescendant(profile_id, expected_id);
+}
+
+
 void AccessControl::setCustomSettingsPrefixes(const Strings & prefixes)
 {
     custom_settings_prefixes->registerPrefixes(prefixes);

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -138,6 +138,9 @@ public:
     /// Sets the default profile's name.
     /// The default profile's settings are always applied before any other profile's.
     void setDefaultProfileName(const String & default_profile_name);
+    std::optional<UUID> getDefaultProfileId() const;
+    bool isDefaultProfileOrDescendant(const UUID & profile_id) const;
+    bool isExpectedProfileOrDescendant(const UUID & profile_id, const UUID & expected_id) const;
 
     /// Sets prefixes which should be used for custom settings.
     /// This function also enables custom prefixes to be used.

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -18,6 +18,7 @@ namespace Setting
 {
     extern const SettingsBool allow_ddl;
     extern const SettingsUInt64 readonly;
+    extern const SettingsBool allow_non_default_profile;
 }
 
 namespace ErrorCodes
@@ -151,6 +152,18 @@ void SettingsConstraints::check(const Settings & current_settings, const Setting
     {
         if (SettingsProfileElements::isAllowBackupSetting(element.setting_name))
             continue;
+
+        if (!current_settings[Setting::allow_non_default_profile])
+        {
+            if (element.parent_profile.has_value())
+            {
+                const auto & profile_id = element.parent_profile.value();
+                if (!access_control->isDefaultProfileOrDescendant(profile_id))
+                {
+                    throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "All profiles must be the default profile or inherit from it.");
+                }
+            }
+        }
 
         if (element.value)
         {

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -22,6 +22,9 @@ public:
     ~SettingsProfilesCache();
 
     void setDefaultProfileName(const String & default_profile_name);
+    std::optional<UUID> getDefaultProfileId();
+    bool isDefaultProfileOrDescendant(const UUID & profile_id);
+    bool isExpectedProfileOrDescendant(const UUID & profile_id, const UUID & expected_id);
 
     std::shared_ptr<const EnabledSettings> getEnabledSettings(
         const UUID & user_id,
@@ -37,6 +40,8 @@ private:
     void profileRemoved(const UUID & profile_id);
     void mergeSettingsAndConstraints();
     void mergeSettingsAndConstraintsFor(EnabledSettings & enabled) const;
+
+    bool isExpectedProfileOrDescendantLocked(const UUID & profile_id, const UUID & expected_id) const;
 
     void substituteProfiles(SettingsProfileElements & elements,
         std::vector<UUID> & profiles,

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2545,6 +2545,10 @@ Maximum size of query syntax tree in number of nodes after expansion of aliases 
 0 - no read-only restrictions. 1 - only read requests, as well as changing explicitly allowed settings. 2 - only read requests, as well as changing settings, except for the 'readonly' setting.
 )", 0) \
     \
+    DECLARE(Bool, allow_non_default_profile, true, R"(
+When enabled, a user, role or settings profile can have a profile that is not the default profile or one of its descendants.
+)", 0) \
+    \
     DECLARE(UInt64, max_rows_in_set, 0, R"(
 Maximum size of the set (in number of elements) resulting from the execution of the IN section.
 )", 0) \

--- a/src/Interpreters/Access/InterpreterCreateSettingsProfileQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateSettingsProfileQuery.cpp
@@ -4,6 +4,7 @@
 #include <Access/AccessControl.h>
 #include <Access/Common/AccessFlags.h>
 #include <Access/SettingsProfile.h>
+#include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Interpreters/removeOnClusterClauseIfNeeded.h>
@@ -13,10 +14,15 @@
 
 namespace DB
 {
+namespace Setting
+{
+    extern const SettingsBool allow_non_default_profile;
+}
 
 namespace ErrorCodes
 {
     extern const int ACCESS_ENTITY_ALREADY_EXISTS;
+    extern const int SETTING_CONSTRAINT_VIOLATION;
 }
 
 namespace
@@ -61,14 +67,71 @@ BlockIO InterpreterCreateSettingsProfileQuery::execute()
     else
         getContext()->checkAccess(AccessType::CREATE_SETTINGS_PROFILE);
 
+    std::vector<UUID> name_ids;
+    if (query.alter)
+    {
+        if (query.if_exists)
+        {
+            name_ids = access_control.find<SettingsProfile>(query.names);
+        }
+        else
+        {
+            name_ids = access_control.getIDs<SettingsProfile>(query.names);
+        }
+    }
+    bool has_parent_profile = false;
     std::optional<AlterSettingsProfileElements> settings_from_query;
     if (query.alter_settings)
         settings_from_query = AlterSettingsProfileElements{*query.alter_settings, access_control};
     else if (query.settings)
         settings_from_query = AlterSettingsProfileElements{SettingsProfileElements(*query.settings, access_control)};
+    if (settings_from_query)
+    {
+        for (const auto & element : settings_from_query->add_settings)
+        {
+            if (element.parent_profile.has_value())
+            {
+                has_parent_profile = true;
+                for (const auto & name_id: name_ids)
+                {
+                    if (access_control.isExpectedProfileOrDescendant(element.parent_profile.value(), name_id))
+                    {
+                        throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "Inherited profiles may not have circular dependencies");
+                    }
+                }
+            }
+        }
+        // This checks that each defined parent is either default or inheriting from it
+        if (!query.attach)
+            getContext()->checkSettingsConstraints(*settings_from_query, SettingSource::PROFILE);
+    }
 
-    if (settings_from_query && !query.attach)
-        getContext()->checkSettingsConstraints(*settings_from_query, SettingSource::PROFILE);
+    // If the query is a create (= not an alter), then it must either be the default
+    // or have a parent profile (which has been checked to be to inherit from default).
+    // If the query is an alter and it has settings change, same thing applies.
+    // A query can be an alter without settings change if it's a noop or just renaming the profile itself.
+    // Instead of rejecting a query without a parent, we auto-inject the default profile as a parent.
+    if (!query.alter || settings_from_query)
+    {
+        if (!has_parent_profile && !getContext()->getSettingsRef()[Setting::allow_non_default_profile])
+        {
+            bool has_default_profile = false;
+            const auto & default_profile_id = access_control.getDefaultProfileId();
+            if (!default_profile_id.has_value())
+                throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "Cannot alter or create profiles if default profile is not configured.");
+            for (const auto & name_id : name_ids)
+                if (name_id == default_profile_id.value())
+                    has_default_profile = true;
+            if (has_default_profile and query.names.size() > 1)
+                throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "Cannot alter the default and other profiles simultaneously.");
+            SettingsProfileElement default_parent;
+            default_parent.parent_profile = default_profile_id;
+            default_parent.setting_name = "profile";
+            if (!settings_from_query.has_value())
+                settings_from_query = AlterSettingsProfileElements();
+            settings_from_query->add_settings.insert(settings_from_query->add_settings.begin(), default_parent);
+        }
+    }
 
     if (!query.cluster.empty())
     {


### PR DESCRIPTION
We want to restrict settings using the default profile, while having less restricted settings for our superadmin user with the admin profile.

We also grant the user the capability to create its own users, roles and settings profile.

Normally, you cannot switch to settings profiles that are less restrictive than your current profile, ClickHouse verifies the new profiles against the constraints of the current profile.

However, when you can create new users, roles, etc. You can create users that use the admin profile, then directly connect with this user.

This way you can skip the verification that happens while switching profiles and escape the constraints of the default profile.

Prevent that by enforcing that all created profiles must inherit from the default profile or one of its descendants, unless the current has a settings allowing to skip that: `allow_non_default_profile`.

This works for us because the admin profile is pre-created using users.xml and not via SQL, so it can already exist and be configured with `allow_non_default_profile` set to true, while the pre-created default profile has `allow_non_default_profile` set to false.

This commit was applied from the patch file 0056-Unescapable_default_profile.patch