### PR TITLE
Add support for protected roles

### DIFF
--- a/src/Access/Role.cpp
+++ b/src/Access/Role.cpp
@@ -10,7 +10,8 @@ bool Role::equal(const IAccessEntity & other) const
     if (!IAccessEntity::equal(other))
         return false;
     const auto & other_role = typeid_cast<const Role &>(other);
-    return (access == other_role.access) && (granted_roles == other_role.granted_roles) && (settings == other_role.settings);
+    return (access == other_role.access) && (granted_roles == other_role.granted_roles) && (settings == other_role.settings)
+        && (protected_flag == other_role.protected_flag);
 }
 
 std::vector<UUID> Role::findDependencies() const

--- a/src/Access/Role.h
+++ b/src/Access/Role.h
@@ -14,6 +14,7 @@ struct Role : public IAccessEntity
     AccessRights access;
     GrantedRoles granted_roles;
     SettingsProfileElements settings;
+    bool protected_flag = false;
 
     bool equal(const IAccessEntity & other) const override;
     std::shared_ptr<IAccessEntity> clone() const override { return cloneImpl<Role>(); }
@@ -28,6 +29,7 @@ struct Role : public IAccessEntity
     void clearAllExceptDependencies() override;
 
     bool isBackupAllowed() const override { return settings.isBackupAllowed(); }
+    bool isProtected() const override { return protected_flag; }
 };
 
 using RolePtr = std::shared_ptr<const Role>;

--- a/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
@@ -2,7 +2,11 @@
 #include <Interpreters/Access/InterpreterCreateRoleQuery.h>
 
 #include <Access/AccessControl.h>
+#include <Access/ContextAccess.h>
+#include <Access/IAccessStorage.h>
 #include <Access/Role.h>
+#include <Access/Common/AccessType.h>
+#include <Access/Common/AccessFlags.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Interpreters/removeOnClusterClauseIfNeeded.h>
@@ -38,6 +42,8 @@ namespace
             role.settings.applyChanges(AlterSettingsProfileElements{*query.alter_settings});
         else if (query.settings)
             role.settings.applyChanges(AlterSettingsProfileElements{*query.settings});
+
+        role.protected_flag = query.protected_flag;
     }
 }
 
@@ -48,6 +54,7 @@ BlockIO InterpreterCreateRoleQuery::execute()
     const auto & query = updated_query_ptr->as<const ASTCreateRoleQuery &>();
 
     auto & access_control = getContext()->getAccessControl();
+    auto access = getContext()->getAccess();
 
     const auto access_type = query.alter ? AccessType::ALTER_ROLE : AccessType::CREATE_ROLE;
     for (const auto & name : query.names)
@@ -55,6 +62,10 @@ BlockIO InterpreterCreateRoleQuery::execute()
 
     if (!query.new_name.empty() && !query.alter)
         getContext()->checkAccess(AccessType::CREATE_ROLE, query.new_name);
+
+    // Statements containing the PROTECTED keyword require an extra privilege
+    if (query.protected_flag)
+        access->checkAccess(AccessFlags{AccessType::PROTECTED_ACCESS_MANAGEMENT});
 
     std::optional<AlterSettingsProfileElements> settings_from_query;
     if (query.alter_settings)
@@ -65,9 +76,6 @@ BlockIO InterpreterCreateRoleQuery::execute()
     if (settings_from_query && !query.attach)
         getContext()->checkSettingsConstraints(*settings_from_query, SettingSource::ROLE);
 
-    if (!query.cluster.empty())
-        return executeDDLQueryOnCluster(updated_query_ptr, getContext());
-
     IAccessStorage * storage = &access_control;
     MultipleAccessStorage::StoragePtr storage_ptr;
 
@@ -76,6 +84,26 @@ BlockIO InterpreterCreateRoleQuery::execute()
         storage_ptr = access_control.getStorageByName(query.storage_name);
         storage = storage_ptr.get();
     }
+
+    /// Enforce the protected-flag policy on the initiator before any ON CLUSTER
+    /// dispatch, so the check cannot be bypassed via DDLWorker.
+    {
+        auto check_protected_change = [&](bool existing_is_protected)
+        {
+            if (existing_is_protected || query.protected_flag)
+                access->checkAccess(AccessFlags{AccessType::PROTECTED_ACCESS_MANAGEMENT});
+        };
+
+        if (query.alter || query.or_replace)
+        {
+            for (const auto & name : query.names)
+                if (auto existing = storage->tryRead<Role>(name))
+                    check_protected_change(existing->isProtected());
+        }
+    }
+
+    if (!query.cluster.empty())
+        return executeDDLQueryOnCluster(updated_query_ptr, getContext());
 
     if (query.alter)
     {
@@ -116,7 +144,16 @@ BlockIO InterpreterCreateRoleQuery::execute()
         if (query.if_not_exists)
             storage->tryInsert(new_roles);
         else if (query.or_replace)
-            storage->insertOrReplace(new_roles, check_func);
+        {
+            /// Defense-in-depth: re-check the protected-flag policy atomically inside the
+            /// storage operation. The pre-dispatch loop above already validated this.
+            IAccessStorage::CheckFunc protected_role_check = [&](const AccessEntityPtr & existing)
+            {
+                if (existing->isProtected() || query.protected_flag)
+                    access->checkAccess(AccessFlags{AccessType::PROTECTED_ACCESS_MANAGEMENT});
+            };
+            storage->insertOrReplace(new_roles, protected_role_check);
+        }
         else
             storage->insert(new_roles, check_func);
     }

--- a/src/Interpreters/Access/InterpreterShowCreateAccessEntityQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowCreateAccessEntityQuery.cpp
@@ -107,6 +107,9 @@ namespace
         query->names.emplace_back(role.getName());
         query->attach = attach_mode;
 
+        if (role.isProtected())
+            query->protected_flag = true;
+
         if (!role.settings.empty())
         {
             std::shared_ptr<ASTSettingsProfileElements> query_settings;

--- a/src/Parsers/Access/ASTCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRoleQuery.cpp
@@ -81,6 +81,9 @@ void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
 
     formatNames(names, ostr);
 
+    if (protected_flag && !alter)
+        ostr << " PROTECTED";
+
     if (!storage_name.empty())
         ostr << (format.hilite ? IAST::hilite_keyword : "")
                     << " IN " << (format.hilite ? IAST::hilite_none : "")

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -35,6 +35,7 @@ public:
     Strings names;
     String new_name;
     String storage_name;
+    bool protected_flag = false;
 
     std::shared_ptr<ASTSettingsProfileElements> settings;
     std::shared_ptr<ASTAlterSettingsProfileElements> alter_settings;

--- a/src/Parsers/Access/ParserCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRoleQuery.cpp
@@ -105,11 +105,37 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     std::shared_ptr<ASTAlterSettingsProfileElements> alter_settings;
     String cluster;
     String storage_name;
+    bool protected_flag = false;
 
     while (true)
     {
         if (alter && new_name.empty() && (names.size() == 1) && parseRenameTo(pos, expected, new_name))
             continue;
+
+        if (!alter && ParserKeyword{Keyword::PROTECTED}.ignore(pos, expected))
+        {
+            protected_flag = true;
+            continue;
+        }
+
+        if (alter)
+        {
+            auto saved_pos = pos;
+            if (ParserKeyword{Keyword::NOT}.ignore(pos, expected))
+            {
+                if (ParserKeyword{Keyword::PROTECTED}.ignore(pos, expected))
+                {
+                    protected_flag = false;
+                    continue;
+                }
+                pos = saved_pos;
+            }
+            if (ParserKeyword{Keyword::PROTECTED}.ignore(pos, expected))
+            {
+                protected_flag = true;
+                continue;
+            }
+        }
 
         if (alter)
         {
@@ -157,6 +183,7 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     query->settings = std::move(settings);
     query->alter_settings = std::move(alter_settings);
     query->storage_name = std::move(storage_name);
+    query->protected_flag = protected_flag;
 
     return true;
 }


### PR DESCRIPTION
Extends the existing protected-entity mechanism (the per-entity `Protected` flag plus the `PROTECTED_ACCESS_MANAGEMENT` global privilege, SQL keyword `PROTECTED`) to ROLE entities. A role marked `PROTECTED` can only be created, altered, renamed, replaced, dropped, moved between storages, or have its grants changed by a principal holding `PROTECTED_ACCESS_MANAGEMENT`. This lets service-managed roles exist as real SQL roles that ordinary cluster users cannot remove or tamper with.

Role-specific changes:
- Role: add a `protected_flag` member, an `isProtected()` override, and include the flag in `equal()`.
- ASTCreateRoleQuery / ParserCreateRoleQuery: carry and parse the `PROTECTED` keyword on CREATE ROLE and `[NOT] PROTECTED` on ALTER ROLE, and round-trip it in `formatImpl`.
- InterpreterCreateRoleQuery: require `PROTECTED_ACCESS_MANAGEMENT` when the statement sets `PROTECTED`; before any ON CLUSTER dispatch, read the existing role (ALTER and CREATE OR REPLACE) and require the privilege when the existing or new role is protected; re-check atomically via the `insertOrReplace` CheckFunc as defense-in-depth.
- InterpreterShowCreateAccessEntityQuery: emit `PROTECTED` so the flag survives SHOW CREATE, ZooKeeper replication and backup/restore.

The storage-layer CheckFunc plumbing and the DROP, GRANT/REVOKE and MOVE interpreters are entity-agnostic and already key off `isProtected()`, so DROP ROLE, GRANT/REVOKE and MOVE on a protected role are covered without further changes.

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
